### PR TITLE
adding_checkSudo_to_v_vb

### DIFF
--- a/include/vanilla
+++ b/include/vanilla
@@ -1,6 +1,8 @@
 #!/bin/bash
 # https://keyaedisa.github.io/ !!
 
+checkSudo
+
 echo "Oki! Preparing to build a Vanilla Arch ISO using latest monthly ${fgCyan}Releng${txReset} profile!"
 echo
 

--- a/include/vanillaBaseline
+++ b/include/vanillaBaseline
@@ -1,6 +1,8 @@
 #!/bin/bash
 # https://keyaedisa.github.io/ !!
 
+checkSudo
+
 echo "Oki! Preparing to build a Vanilla Arch ISO using latest monthly ${fgCyan}Baseline${txReset} profile!"
 echo "Do keep in mind this ISO will have only just enough for you to boot it as a live ISO! ${fgRed}Nothing${txReset} more!"
 echo


### PR DESCRIPTION
Don't know if it needs to be added to these but I noticed it since I ran abs -v in my rooted terminal tab and every other option says Must NOT run abs as root.